### PR TITLE
Ignore robots by default

### DIFF
--- a/retrieve_plex_download_url.py
+++ b/retrieve_plex_download_url.py
@@ -4,6 +4,7 @@ Retrieves the latests Plex Media Server PlexPass downlaod URL for Debian 64-bit.
 '''
 import os
 import sys
+import ssl
 try:
     import mechanize
 except ImportError:
@@ -14,6 +15,9 @@ __author__ = 'Werner Beroux <werner@beroux.com>'
 
 
 def retrieve_latest_download_url(login, password):
+    # Ignore SSL certificate errors
+    ssl._create_default_https_context = ssl._create_unverified_context
+    
     browser = mechanize.Browser()
     
     # Ignore robots by default

--- a/retrieve_plex_download_url.py
+++ b/retrieve_plex_download_url.py
@@ -15,6 +15,9 @@ __author__ = 'Werner Beroux <werner@beroux.com>'
 
 def retrieve_latest_download_url(login, password):
     browser = mechanize.Browser()
+    
+    # Ignore robots by default
+    browser.set_handle_robots(False)
 
     if login and password:
         sys.stderr.write('Retrieving the latest Plex release for PlexPass users...\n')


### PR DESCRIPTION
By default mechanize checks robots.txt before doing anything more, and since Plex is now using robots.txt we need to bypass this in order to make the container work. Obviously not what the Plex team wants

This fixes:

```
+ /retrieve_plex_download_url.py
Retrieving the latest Plex release for PlexPass users...
Traceback (most recent call last):
  File "/retrieve_plex_download_url.py", line 44, in <module>
    print(retrieve_latest_download_url(login, password))
  File "/retrieve_plex_download_url.py", line 21, in retrieve_latest_download_url
    browser.open('https://plex.tv/users/sign_in')
  File "/usr/lib/python2.7/dist-packages/mechanize/_mechanize.py", line 203, in open
    return self._mech_open(url, data, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/mechanize/_mechanize.py", line 255, in _mech_open
    raise response
mechanize._response.httperror_seek_wrapper: HTTP Error 403: request disallowed by robots.txt
+ curl -L -o plexmediaserver.deb
curl: /usr/lib/plexmediaserver/libcurl.so.4: no version information available (required by curl)
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
```

and (when applying ignore robots.txt patch you get:)

```
+ /retrieve_plex_download_url.py
Retrieving the latest Plex release for PlexPass users...
Traceback (most recent call last):
  File "/retrieve_plex_download_url.py", line 45, in <module>
    print(retrieve_latest_download_url(login, password))
  File "/retrieve_plex_download_url.py", line 22, in retrieve_latest_download_url
    browser.open('https://plex.tv/users/sign_in')
  File "/usr/lib/python2.7/dist-packages/mechanize/_mechanize.py", line 203, in open
    return self._mech_open(url, data, timeout=timeout)
  File "/usr/lib/python2.7/dist-packages/mechanize/_mechanize.py", line 230, in _mech_open
    response = UserAgentBase.open(self, request, data)
  File "/usr/lib/python2.7/dist-packages/mechanize/_opener.py", line 193, in open
    response = urlopen(self, req, data)
  File "/usr/lib/python2.7/dist-packages/mechanize/_urllib2_fork.py", line 344, in _open
    '_open', req)
  File "/usr/lib/python2.7/dist-packages/mechanize/_urllib2_fork.py", line 332, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/dist-packages/mechanize/_urllib2_fork.py", line 1170, in https_open
    return self.do_open(conn_factory, req)
  File "/usr/lib/python2.7/dist-packages/mechanize/_urllib2_fork.py", line 1118, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:581)>
+ curl -L -o plexmediaserver.deb
curl: /usr/lib/plexmediaserver/libcurl.so.4: no version information available (required by curl)
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
```
