### PR TITLE
Automatically connect you Plex account to the container without SSH Port Forward or other tricks.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN useradd --system --uid 797 -M --shell /usr/sbin/nologin plex \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        xmlstarlet \
  && DOWNLOAD_URL=`curl -Ls https://plex.tv/downloads \
     | grep -o '[^"'"'"']*amd64.deb' \
     | grep -v binaries` \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ RUN useradd --system --uid 797 -M --shell /usr/sbin/nologin plex \
  && dpkg -i plexmediaserver.deb \
  && rm -f plexmediaserver.deb \
  && rm -f /bin/start \
- && apt-get purge -y --auto-remove \
-        curl \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir /config \
@@ -49,6 +47,8 @@ ENV LD_LIBRARY_PATH /usr/lib/plexmediaserver
 ENV TMPDIR /tmp
 
 ADD *.sh /
+
+ADD Preferences.xml /Preferences.xml
 
 USER plex
 

--- a/Preferences.xml
+++ b/Preferences.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Preferences ManualPortMappingMode="1" AcceptedEULA="1" PublishServerOnPlexOnlineKey="1" />

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,35 @@ then
     rm -f /config/Plex\ Media\ Server/plexmediaserver.pid
 fi
 
+# Get plex token if PLEX_USERNAME and PLEX_PASSWORD are define
+[ "${PLEX_USERNAME}" ] && [ "${PLEX_PASSWORD}" ] && {
+
+  # Ask Plex.tv a token key
+  TOKEN=$(curl -u "${PLEX_USERNAME}":"${PLEX_PASSWORD}" 'https://plex.tv/users/sign_in.xml' \
+    -X POST -H 'X-Plex-Device-Name: PlexMediaServer' \
+    -H 'X-Plex-Provides: server' \
+    -H 'X-Plex-Version: 0.9' \
+    -H 'X-Plex-Platform-Version: 0.9' \
+    -H 'X-Plex-Platform: xcid' \
+    -H 'X-Plex-Product: Plex Media Server'\
+    -H 'X-Plex-Device: Linux'\
+    -H 'X-Plex-Client-Identifier: XXXX' --compressed | sed -n 's/.*<authentication-token>\(.*\)<\/authentication-token>.*/\1/p')
+
+  if [ ! -f /config/Plex\ Media\ Server/Preferences.xml ]; then
+    mkdir -p /config/Plex\ Media\ Server
+    cp /Preferences.xml /config/Plex\ Media\ Server/Preferences.xml
+  fi
+
+  if [ ! $(xmlstarlet sel -T -t -m "/Preferences" -v "@PlexOnlineToken" -n /config/Plex\ Media\ Server/Preferences.xml) ]; then
+    xmlstarlet ed --inplace --insert "Preferences" --type attr -n PlexOnlineToken -v ${TOKEN} /config/Plex\ Media\ Server/Preferences.xml
+  fi
+
+  if [ "${PLEX_EXTERNALPORT}" ]; then
+    xmlstarlet ed --inplace --insert "Preferences" --type attr -n ManualPortMappingPort -v ${PLEX_EXTERNALPORT} /config/Plex\ Media\ Server/Preferences.xml
+  fi
+
+}
+
 # Set the stack size
 ulimit -s $PLEX_MAX_STACK_SIZE
 


### PR DESCRIPTION
Automatically connect you Plex account to the container without SSH Port Forward or other tricks.

Username and password are used to cat Plex.tv api to get an app token. Then add it to Preferences.xml and your Plex Media is Automatically linked to your account

ENV Variables to use :
`PLEX_USERNAME`
`PLEX_PASSWORD`

example : 

```
docker run -d --name plex \ 
              -e PLEX_USERNAME=xcid  \
              -e PLEX_PASSWORD=password  \ 
              --restart=always \ 
              -v ~/plex-config:/config \ 
              -v ~/Movies:/media \ 
              -p 32400:32400 wernight/plex-media-server
```

If you are using a different external port than 32400, you will have to user `PLEX_EXTERNALPORT`

```
docker run -d --name plex \ 
              -e PLEX_USERNAME=xcid  \
              -e PLEX_PASSWORD=password  \ 
              -e PLEX_EXTERNALPORT=33400  \
              --restart=always \ 
              -v ~/plex-config:/config \ 
              -v ~/Movies:/media \ 
              -p 32400:32400 wernight/plex-media-server
```
