### PR TITLE
Use wget instead of curl to avoid restart issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN set -x \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
-        curl \
+        wget \
         dumb-init \
         xmlstarlet \
  && apt-get clean \

--- a/root/install_run_plex.sh
+++ b/root/install_run_plex.sh
@@ -17,7 +17,7 @@ else
 
     # Download and install Plex Media Server
     echo 'Downloading Plex Media Server...'
-    curl -L $PLEX_FORCE_DOWNLOAD_URL -o plexmediaserver.deb
+    wget -O plexmediaserver.deb $PLEX_FORCE_DOWNLOAD_URL
 
     echo 'Installing Plex Media Server...'
     dpkg -i plexmediaserver.deb


### PR DESCRIPTION
#41 The copy of curl provided by plex was causing issues with the curl command after containers were restarted. This fixes that by using wget instead. Note that I have not updated retrieve-plex-token to use wget